### PR TITLE
add support for [].map(uniq)

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = uniq;
  */
 
 function uniq(el, arr){
-  arr = arr || [];
+  arr = arr instanceof Array ? arr : [];
   if (!el) return arr.join(' > ');
   arr.unshift(selector(el));
   if (el.id) return arr.join(' > ');

--- a/test/test.js
+++ b/test/test.js
@@ -13,4 +13,14 @@ cases.forEach(function(test){
       assert(el == html.querySelector(ret), 'expected "' + ret + '" to get "' + test.element + '"');
     })
   })
+
+  describe('[' + test.element + '].map(uniq)', function(){
+    it('should return "' + test.expect + '" of "' + test.of + '"', function(){
+      var html = domify(test.of);
+      var els = [].slice.call(html.querySelectorAll(test.selector));
+      var ret = els.map(uniq)[0];
+      assert(test.expect == ret, 'expected "' + test.expect + '" got "' + ret + '"');
+      assert(els[0] == html.querySelector(ret), 'expected "' + ret + '" to get "' + test.element + '"');
+    })
+  });
 })


### PR DESCRIPTION
Hey, it'd be nice to be able to use this with `Array.prototype.map`.
Currently, because of `[].map`'s extra arguments, you have to do something like this:

```
els.map(function(el){ return uniq(el) });
```

This adds the ability to do:

```
els.map(uniq);
```
