### PR TITLE
support svg elements, check arrays with arr.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = uniq;
  */
 
 function uniq(el, arr){
-  arr = arr instanceof Array ? arr : [];
+  arr = arr && arr.join ? arr : [];
   if (!el) return arr.join(' > ');
   arr.unshift(selector(el));
   if (el.id) return arr.join(' > ');
@@ -39,7 +39,7 @@ function uniq(el, arr){
  */
 
 function selector(el){
-  var classname = trim(el.className);
+  var classname = trim(el.className.baseVal ? el.className.baseVal : el.className);
   var i = index(el);
 
   return el.tagName.toLowerCase()

--- a/test/cases.js
+++ b/test/cases.js
@@ -38,3 +38,12 @@ cases.push({
   expect: 'p.foo.bar > i:nth-child(1)',
   selector: 'i'
 });
+
+// works on svg elements
+
+cases.push({
+  element: '<svg class=" foo bar ">',
+  of: '<div><svg class=" foo bar "></svg></p>',
+  expect: 'div > svg.foo.bar:nth-child(1)',
+  selector: 'svg'
+});


### PR DESCRIPTION
bummer, looks like on `svg`, `el.className` is an object, not a string.

I also replaced `arr instanceof Array` by `arr.join ?` as it's faster (http://jsperf.com/array-like-checks/2)
