### PR TITLE
index: Fix attached elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ module.exports = uniq;
 function uniq(el, arr){
   arr = arr && arr.join ? arr : [];
   if (!el) return arr.join(' > ');
-  arr.unshift(selector(el));
-  if (el.id) return arr.join(' > ');
   if (9 == el.nodeType) return arr.join(' > ');
   if (1 != el.nodeType) return arr.join(' > ');
+  arr.unshift(selector(el));
+  if (el.id) return arr.join(' > ');
   return uniq(el.parentNode, arr);
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,3 +24,11 @@ cases.forEach(function(test){
     })
   });
 })
+
+describe('uniq(attached element)', function(){
+  it('should work', function(){
+    var el = document.createElement('div');
+    document.body.appendChild(el);
+    uniq(el);
+  })
+});


### PR DESCRIPTION
Passing `document` into the private `selector` function throws a `TypeError`.  This will happen when an (attached) element is provided whose parents don't have IDs.

Closes #4.
