### PR TITLE
uniq(el) should return a string selectable with document.querySelector

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function uniq(el, arr){
 
 function selector(el){
   var classname = trim(el.className.baseVal ? el.className.baseVal : el.className);
-  var i = index(el);
+  var i = el.parentNode && 9 == el.parentNode.nodeType ? -1 : index(el);
 
   return el.tagName.toLowerCase()
     + (el.id ? '#' + el.id : '')

--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,12 @@ describe('uniq(attached element)', function(){
     uniq(el);
   })
 });
+
+describe('document.querySelector(uniq(el))', function(){
+  it('should return a selectable string', function(){
+    var el = document.createElement('div');
+    document.body.appendChild(el);
+    var found = document.querySelector(uniq(el));
+    assert(found, 'document.querySelector(uniq(el)) did not return `el`.');
+  })
+});


### PR DESCRIPTION
Hi,

if `uniq(el)` has to recursively go up to `document`, the string it returns is not selectable because `document.querySelector('html:nth-child(1)')` returns `null`, whereas `document.querySelector('html')` works (tested in chrome).

Not sure if this should be in `indexof` ? It seems like the use case is specific to `uniq-selector`.
